### PR TITLE
Add `HttpRequest` and `ShellExec` commands

### DIFF
--- a/src/orcha/commands/HttpRequest/CMakeLists.txt
+++ b/src/orcha/commands/HttpRequest/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(HttpRequest)
+
+set(CMAKE_CXX_STANDARD 20)
+find_package(cpprestsdk REQUIRED)
+
+add_library(HttpRequest SHARED HttpRequest.cpp)
+target_include_directories(HttpRequest PRIVATE ${CMAKE_SOURCE_DIR}/core)
+target_link_libraries(HttpRequest PRIVATE cpprestsdk::cpprest)
+set_target_properties(HttpRequest PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/commands
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/commands
+)

--- a/src/orcha/commands/HttpRequest/HttpRequest.cpp
+++ b/src/orcha/commands/HttpRequest/HttpRequest.cpp
@@ -1,0 +1,171 @@
+//
+// HttpRequest.cpp - Perform an HTTP request and capture the response.
+//
+
+#include "../../core/ICommand.hpp"
+#include "core/Version.hpp"
+
+#include <cpprest/http_client.h>
+#include <cpprest/json.h>
+
+#include <chrono>
+#include <stdexcept>
+#include <string>
+
+class HttpRequest final : public Orcha::Core::ICommand {
+public:
+    [[nodiscard]] std::string name() const override { return "http_request"; }
+
+    web::json::value execute(const web::json::value& params) override {
+        using namespace web;
+        using namespace utility;
+
+        try {
+            json::value result;
+            if (!params.has_field(U("url"))) {
+                throw std::runtime_error("'url' parameter is required");
+            }
+            const auto url = params.at(U("url")).as_string();
+
+            const std::string method_str = params.has_field(U("method"))
+                ? conversions::to_utf8string(params.at(U("method")).as_string())
+                : "GET";
+            const auto method = resolve_method(method_str);
+
+            http::http_request request(method);
+
+            if (params.has_field(U("headers")) && params.at(U("headers")).is_object()) {
+                for (const auto& kv : params.at(U("headers")).as_object()) {
+                    if (kv.second.is_string()) {
+                        request.headers().add(kv.first, kv.second.as_string());
+                    }
+                }
+            }
+
+            if (params.has_field(U("body"))) {
+                const auto& body = params.at(U("body"));
+                if (body.is_string()) {
+                    request.set_body(body.as_string());
+                } else {
+                    // Accept structured JSON bodies too.
+                    request.set_body(body);
+                }
+            }
+
+            http::client::http_client_config config;
+            if (params.has_field(U("timeout_ms"))) {
+                config.set_timeout(std::chrono::milliseconds(
+                    params.at(U("timeout_ms")).as_integer()));
+            }
+
+            http::client::http_client client(url, config);
+            const auto response  = client.request(request).get();
+            const auto status    = response.status_code();
+            const auto body_str  = response.extract_string().get();
+
+            result[U("success")]     = json::value::boolean(status >= 200 && status < 300);
+            result[U("status_code")] = json::value::number(static_cast<int>(status));
+            result[U("body")]        = json::value::string(body_str);
+
+            json::value headers_out = json::value::object();
+            for (const auto& h : response.headers()) {
+                headers_out[h.first] = json::value::string(h.second);
+            }
+            result[U("headers")] = headers_out;
+            return result;
+        } catch (const std::exception& ex) {
+            json::value err;
+            err[U("success")] = json::value(false);
+            err[U("error")]   = json::value::string(conversions::to_string_t(ex.what()));
+            return err;
+        }
+    }
+
+    [[nodiscard]] Orcha::Core::CommandMetadata metadata() const override {
+        Orcha::Core::CommandMetadata meta;
+        meta.name = "http_request";
+        meta.version = Orcha::kVersion;
+        meta.description = "Performs an HTTP request and returns the response";
+        meta.author = "Orcha Team";
+        meta.tags = {"http", "network", "utility"};
+        meta.supports_rollback = false;
+
+        Orcha::Core::CommandParameter url_p;
+        url_p.name = "url";
+        url_p.type = "string";
+        url_p.required = true;
+        url_p.description = "URL to request";
+        url_p.example = "https://api.example.com/status";
+        meta.parameters.push_back(url_p);
+
+        Orcha::Core::CommandParameter method_p;
+        method_p.name = "method";
+        method_p.type = "string";
+        method_p.required = false;
+        method_p.description = "HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)";
+        method_p.default_value = "GET";
+        meta.parameters.push_back(method_p);
+
+        Orcha::Core::CommandParameter headers_p;
+        headers_p.name = "headers";
+        headers_p.type = "object";
+        headers_p.required = false;
+        headers_p.description = "Request headers as a JSON object of string values";
+        meta.parameters.push_back(headers_p);
+
+        Orcha::Core::CommandParameter body_p;
+        body_p.name = "body";
+        body_p.type = "string";
+        body_p.required = false;
+        body_p.description = "Request body (string; JSON values are also accepted)";
+        meta.parameters.push_back(body_p);
+
+        Orcha::Core::CommandParameter timeout_p;
+        timeout_p.name = "timeout_ms";
+        timeout_p.type = "int";
+        timeout_p.required = false;
+        timeout_p.description = "Request timeout in milliseconds";
+        meta.parameters.push_back(timeout_p);
+
+        return meta;
+    }
+
+    // The default validate() would reject non-string bodies; override to permit
+    // either string or structured JSON, while still checking required/url types.
+    [[nodiscard]] Orcha::Core::Result<void, Orcha::Core::ValidationError> validate(
+        const web::json::value& params) const override {
+        using R = Orcha::Core::Result<void, Orcha::Core::ValidationError>;
+        if (!params.has_field(U("url"))) {
+            return R::Err({"url", "Required parameter missing"});
+        }
+        if (!params.at(U("url")).is_string()) {
+            return R::Err({"url", "Expected string type"});
+        }
+        if (params.has_field(U("method")) && !params.at(U("method")).is_string()) {
+            return R::Err({"method", "Expected string type"});
+        }
+        if (params.has_field(U("headers")) && !params.at(U("headers")).is_object()) {
+            return R::Err({"headers", "Expected object type"});
+        }
+        if (params.has_field(U("timeout_ms")) && !params.at(U("timeout_ms")).is_integer()) {
+            return R::Err({"timeout_ms", "Expected integer type"});
+        }
+        return R::Ok();
+    }
+
+private:
+    static web::http::method resolve_method(const std::string& m) {
+        using namespace web::http;
+        if (m == "GET")    return methods::GET;
+        if (m == "POST")   return methods::POST;
+        if (m == "PUT")    return methods::PUT;
+        if (m == "PATCH")  return methods::PATCH;
+        if (m == "DELETE") return methods::DEL;
+        if (m == "HEAD")   return methods::HEAD;
+        throw std::runtime_error("Unsupported HTTP method: " + m);
+    }
+};
+
+extern "C" Orcha::Core::ICommand* create_command() {
+    return new HttpRequest();
+}

--- a/src/orcha/commands/HttpRequest/manifest.json
+++ b/src/orcha/commands/HttpRequest/manifest.json
@@ -1,0 +1,42 @@
+{
+    "name": "http_request",
+    "version": "1.0.0",
+    "description": "Performs an HTTP request and returns the response",
+    "author": "Orcha Team",
+    "tags": ["http", "network", "utility"],
+    "entry_point": "libHttpRequest.dylib",
+    "parameters": [
+        {
+            "name": "url",
+            "type": "string",
+            "required": true,
+            "description": "URL to request",
+            "example": "https://api.example.com/status"
+        },
+        {
+            "name": "method",
+            "type": "string",
+            "required": false,
+            "description": "HTTP method (GET, POST, PUT, PATCH, DELETE, HEAD)",
+            "default": "GET"
+        },
+        {
+            "name": "headers",
+            "type": "object",
+            "required": false,
+            "description": "Request headers as a JSON object of string values"
+        },
+        {
+            "name": "body",
+            "type": "string",
+            "required": false,
+            "description": "Request body (string; JSON values are also accepted)"
+        },
+        {
+            "name": "timeout_ms",
+            "type": "int",
+            "required": false,
+            "description": "Request timeout in milliseconds"
+        }
+    ]
+}

--- a/src/orcha/commands/ShellExec/CMakeLists.txt
+++ b/src/orcha/commands/ShellExec/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.16)
+project(ShellExec)
+
+set(CMAKE_CXX_STANDARD 20)
+find_package(cpprestsdk REQUIRED)
+
+add_library(ShellExec SHARED ShellExec.cpp)
+target_include_directories(ShellExec PRIVATE ${CMAKE_SOURCE_DIR}/core)
+target_link_libraries(ShellExec PRIVATE cpprestsdk::cpprest)
+set_target_properties(ShellExec PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/commands
+        RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/commands
+)

--- a/src/orcha/commands/ShellExec/ShellExec.cpp
+++ b/src/orcha/commands/ShellExec/ShellExec.cpp
@@ -1,0 +1,134 @@
+//
+// ShellExec.cpp - Run a shell command, capture stdout/stderr and exit code.
+//
+
+#include "../../core/ICommand.hpp"
+#include "core/Version.hpp"
+
+#include <cpprest/json.h>
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+
+#if defined(_WIN32)
+  #define ORCHA_POPEN  _popen
+  #define ORCHA_PCLOSE _pclose
+#else
+  #include <sys/wait.h>
+  #define ORCHA_POPEN  popen
+  #define ORCHA_PCLOSE pclose
+#endif
+
+class ShellExec final : public Orcha::Core::ICommand {
+public:
+    [[nodiscard]] std::string name() const override { return "shell_exec"; }
+
+    web::json::value execute(const web::json::value& params) override {
+        using namespace web;
+        using namespace utility;
+
+        json::value result;
+        try {
+            if (!params.has_field(U("cmd"))) {
+                throw std::runtime_error("'cmd' parameter is required");
+            }
+            const std::string cmd = conversions::to_utf8string(params.at(U("cmd")).as_string());
+
+            const bool capture_output = params.has_field(U("capture_output"))
+                ? params.at(U("capture_output")).as_bool()
+                : true;
+            const bool check_exit = params.has_field(U("check_exit"))
+                ? params.at(U("check_exit")).as_bool()
+                : true;
+
+            // Merge stderr into stdout so we capture both in a single stream.
+            const std::string full_cmd = capture_output ? (cmd + " 2>&1") : cmd;
+
+            std::string captured;
+            int exit_code = 0;
+
+            if (capture_output) {
+                FILE* raw = ORCHA_POPEN(full_cmd.c_str(), "r");
+                if (!raw) {
+                    throw std::runtime_error("Failed to launch process");
+                }
+                std::array<char, 4096> buf{};
+                while (std::fgets(buf.data(), static_cast<int>(buf.size()), raw) != nullptr) {
+                    captured.append(buf.data());
+                }
+                const int rc = ORCHA_PCLOSE(raw);
+#if defined(_WIN32)
+                exit_code = rc;
+#else
+                exit_code = WIFEXITED(rc) ? WEXITSTATUS(rc) : rc;
+#endif
+            } else {
+                const int rc = std::system(full_cmd.c_str());
+#if defined(_WIN32)
+                exit_code = rc;
+#else
+                exit_code = WIFEXITED(rc) ? WEXITSTATUS(rc) : rc;
+#endif
+            }
+
+            const bool ok = (exit_code == 0);
+            result[U("success")]   = json::value::boolean(ok || !check_exit);
+            result[U("exit_code")] = json::value::number(exit_code);
+            result[U("output")]    = json::value::string(conversions::to_string_t(captured));
+
+            if (check_exit && !ok) {
+                result[U("error")] = json::value::string(
+                    conversions::to_string_t("Command exited with code " + std::to_string(exit_code)));
+            }
+            return result;
+        } catch (const std::exception& ex) {
+            json::value err;
+            err[U("success")] = json::value(false);
+            err[U("error")]   = json::value::string(conversions::to_string_t(ex.what()));
+            return err;
+        }
+    }
+
+    [[nodiscard]] Orcha::Core::CommandMetadata metadata() const override {
+        Orcha::Core::CommandMetadata meta;
+        meta.name = "shell_exec";
+        meta.version = Orcha::kVersion;
+        meta.description = "Executes a shell command and captures its output";
+        meta.author = "Orcha Team";
+        meta.tags = {"utility", "shell", "process"};
+        meta.supports_rollback = false;
+
+        Orcha::Core::CommandParameter cmd_p;
+        cmd_p.name = "cmd";
+        cmd_p.type = "string";
+        cmd_p.required = true;
+        cmd_p.description = "Shell command line to execute";
+        cmd_p.example = "echo hello";
+        meta.parameters.push_back(cmd_p);
+
+        Orcha::Core::CommandParameter cap_p;
+        cap_p.name = "capture_output";
+        cap_p.type = "bool";
+        cap_p.required = false;
+        cap_p.description = "Capture merged stdout/stderr in the output field";
+        cap_p.default_value = "true";
+        meta.parameters.push_back(cap_p);
+
+        Orcha::Core::CommandParameter chk_p;
+        chk_p.name = "check_exit";
+        chk_p.type = "bool";
+        chk_p.required = false;
+        chk_p.description = "Treat a non-zero exit code as a failure";
+        chk_p.default_value = "true";
+        meta.parameters.push_back(chk_p);
+
+        return meta;
+    }
+};
+
+extern "C" Orcha::Core::ICommand* create_command() {
+    return new ShellExec();
+}

--- a/src/orcha/commands/ShellExec/manifest.json
+++ b/src/orcha/commands/ShellExec/manifest.json
@@ -1,0 +1,31 @@
+{
+    "name": "shell_exec",
+    "version": "1.0.0",
+    "description": "Executes a shell command and captures its output",
+    "author": "Orcha Team",
+    "tags": ["utility", "shell", "process"],
+    "entry_point": "libShellExec.dylib",
+    "parameters": [
+        {
+            "name": "cmd",
+            "type": "string",
+            "required": true,
+            "description": "Shell command line to execute",
+            "example": "echo hello"
+        },
+        {
+            "name": "capture_output",
+            "type": "bool",
+            "required": false,
+            "description": "Capture merged stdout/stderr in the output field",
+            "default": "true"
+        },
+        {
+            "name": "check_exit",
+            "type": "bool",
+            "required": false,
+            "description": "Treat a non-zero exit code as a failure",
+            "default": "true"
+        }
+    ]
+}

--- a/src/orcha/logs/orcha.log
+++ b/src/orcha/logs/orcha.log
@@ -1,0 +1,17 @@
+[2025-12-13 14:17:39.407][INFO] Starting Orcha...
+[2025-12-13 14:17:39.883][INFO] Loaded plugin: PowerShellDownloader v1.0.0
+[2025-12-13 14:17:40.440][INFO] Loaded plugin: EchoCommand v1.0.0
+[2025-12-13 14:17:40.440][ERROR] Plugin error [echo]: Failed to load library: ./commands/EchoCommand/libEchoCommand.dylib
+[2025-12-13 14:17:40.441][ERROR] Plugin error [create_pg_db]: Failed to load library: ./commands/PostgresCreator/libPostgresCreator.dylib
+[2025-12-13 14:17:40.441][INFO] Loaded 2 plugins
+[2025-12-13 14:17:40.441][INFO] Running workflow from: --help
+[2025-12-13 14:17:40.441][ERROR] Workflow failed: Failed to load YAML: bad file: --help
+[2025-12-13 14:17:40.454][INFO] Starting Orcha...
+[2025-12-13 14:17:40.466][INFO] Loaded plugin: PowerShellDownloader v1.0.0
+[2025-12-13 14:17:40.466][INFO] Loaded plugin: EchoCommand v1.0.0
+[2025-12-13 14:17:40.467][ERROR] Plugin error [echo]: Failed to load library: ./commands/EchoCommand/libEchoCommand.dylib
+[2025-12-13 14:17:40.467][ERROR] Plugin error [create_pg_db]: Failed to load library: ./commands/PostgresCreator/libPostgresCreator.dylib
+[2025-12-13 14:17:40.467][INFO] Loaded 2 plugins
+[2025-12-13 14:17:40.468][INFO] CommandAgent starting on port 8070
+[2025-12-13 14:17:40.468][INFO] CommandAgent listening on port 8070
+[2025-12-13 14:17:40.468][INFO] Shutting down Orcha...

--- a/src/orcha/sample_workflows/http-and-shell.yaml
+++ b/src/orcha/sample_workflows/http-and-shell.yaml
@@ -1,0 +1,26 @@
+name: http-and-shell-demo
+description: Fetches a remote URL, then runs shell commands and surfaces results via templating.
+
+steps:
+  - name: fetch
+    command: http_request
+    params:
+      url: "https://api.github.com/zen"
+      method: GET
+      timeout_ms: 5000
+
+  - command: echo
+    params:
+      message: "github.com/zen responded with status {{step1.output.status_code}}"
+
+  - command: shell_exec
+    params:
+      cmd: "date -u +%FT%TZ && uname -srm"
+
+  - command: echo
+    params:
+      message: "host info: {{step3.output.output}}"
+
+  - command: echo
+    params:
+      message: "zen quote: {{step1.output.body}}"


### PR DESCRIPTION
This pull request introduces two new reusable command modules, `http_request` and `shell_exec`, for the Orcha framework, along with sample workflow usage. These modules allow workflows to perform HTTP requests and execute shell commands, capturing their outputs in a structured way. Each command includes its own CMake build configuration, implementation, and manifest describing parameters and metadata. A sample YAML workflow demonstrates how to use both commands together.

**New command modules**

* Added a new `http_request` command:
  - Performs HTTP requests (GET, POST, etc.), supports custom headers, body, and timeout, and returns status, headers, and response body in JSON. Includes parameter validation and error handling. (`HttpRequest.cpp`, `manifest.json`) [[1]](diffhunk://#diff-b872a9c8b78d87363d0c14448bd62a3f00dc1aae3618444d372b35bfcae66ba6R1-R171) [[2]](diffhunk://#diff-f720a5884d2b4f1bbc206016e558bff1740107b430c7c490ef1ea1272d97bc7bR1-R42)
  - CMake configuration added for building as a shared library. (`CMakeLists.txt`)

* Added a new `shell_exec` command:
  - Executes shell commands, capturing stdout/stderr, exit code, and errors. Supports options to capture output and check exit code. (`ShellExec.cpp`, `manifest.json`) [[1]](diffhunk://#diff-05ea9bee303693aa3032611b48f8b1f49ef1b9d103c3ec34354da0d0e3645269R1-R134) [[2]](diffhunk://#diff-f5e5e21c4fff4b66cff4e117a7014ba5576bf81a76a3c501bb6435ed9478dc33R1-R31)
  - CMake configuration added for building as a shared library. (`CMakeLists.txt`)

**Sample workflow**

* Introduced a sample workflow YAML that demonstrates fetching a URL with `http_request`, running shell commands with `shell_exec`, and surfacing results using templating. (`http-and-shell.yaml`)