### PR TITLE
Dev

### DIFF
--- a/src/orcha/CMakeLists.txt
+++ b/src/orcha/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(core STATIC
         core/CommandRegistry.hpp
         core/PluginManager.cpp
         core/PluginManager.hpp
+        core/PluginDenylist.hpp
 )
 
 add_library(logger STATIC
@@ -73,6 +74,9 @@ add_library(jobs STATIC
         jobs/SqliteJobStore.hpp
         jobs/JobService.hpp
         jobs/RunJobCommand.hpp
+        jobs/CronExpr.hpp
+        jobs/JobScheduler.cpp
+        jobs/JobScheduler.hpp
 )
 target_link_libraries(jobs PUBLIC core workflow logger
         cpprestsdk::cpprest unofficial::sqlite3::sqlite3)

--- a/src/orcha/agent/CommandAgent.cpp
+++ b/src/orcha/agent/CommandAgent.cpp
@@ -27,7 +27,8 @@ namespace Orcha::Agent {
         Config::AdminConfig admin,
         std::string plugin_dir,
         std::chrono::milliseconds watch_interval,
-        std::shared_ptr<Jobs::JobService> jobs)
+        std::shared_ptr<Jobs::JobService> jobs,
+        std::shared_ptr<Core::IPluginDenylist> denylist)
         : registry_(std::move(registry))
         , engine_(std::move(engine))
         , logger_(std::move(logger))
@@ -36,7 +37,8 @@ namespace Orcha::Agent {
         , admin_(std::move(admin))
         , plugin_dir_(std::move(plugin_dir))
         , watch_interval_(watch_interval)
-        , jobs_(std::move(jobs)) {
+        , jobs_(std::move(jobs))
+        , denylist_(std::move(denylist)) {
         setup_default_routes();
     }
 
@@ -91,7 +93,7 @@ namespace Orcha::Agent {
         router_.use(make_basic_auth(admin_, {"/api/"}, logger_));
 
         router_.register_handler(std::make_shared<Routes::PluginAdminRoute>(
-            plugins_, discovery_, registry_, plugin_dir_, watch_interval_, logger_));
+            plugins_, discovery_, registry_, plugin_dir_, watch_interval_, logger_, denylist_));
         router_.register_handler(std::make_shared<Routes::DashboardRoute>(logger_));
 
         // Jobs API (CRUD + run history). Gated by the same Basic-auth middleware.

--- a/src/orcha/agent/CommandAgent.hpp
+++ b/src/orcha/agent/CommandAgent.hpp
@@ -9,6 +9,7 @@
 #include "../core/ICommandRegistry.hpp"
 #include "../core/PluginManager.hpp"
 #include "../core/IPluginDiscovery.hpp"
+#include "../core/PluginDenylist.hpp"
 #include "../workflow/IWorkflowEngine.hpp"
 #include "../workflow/WorkflowEngine.hpp"
 #include "../jobs/JobService.hpp"
@@ -53,7 +54,8 @@ namespace Orcha::Agent {
                     Config::AdminConfig admin = {},
                     std::string plugin_dir = "./commands",
                     std::chrono::milliseconds watch_interval = std::chrono::milliseconds(5000),
-                    std::shared_ptr<Jobs::JobService> jobs = nullptr);
+                    std::shared_ptr<Jobs::JobService> jobs = nullptr,
+                    std::shared_ptr<Core::IPluginDenylist> denylist = nullptr);
 
         ~CommandAgent();
 
@@ -96,6 +98,7 @@ namespace Orcha::Agent {
         std::string plugin_dir_;
         std::chrono::milliseconds watch_interval_;
         std::shared_ptr<Jobs::JobService> jobs_;
+        std::shared_ptr<Core::IPluginDenylist> denylist_;
 
         Router router_;
         std::unique_ptr<web::http::experimental::listener::http_listener> listener_;

--- a/src/orcha/agent/dashboard_embedded.hpp
+++ b/src/orcha/agent/dashboard_embedded.hpp
@@ -130,6 +130,13 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     .runrow { cursor:pointer; }
     .mono { font-family:ui-monospace,SFMono-Regular,Menlo,monospace; font-size:12px;
             white-space:pre-wrap; word-break:break-word; }
+    .outcard { border:1px solid var(--line); border-radius:8px; margin:10px 0; overflow:hidden; }
+    .outcard .hd { display:flex; align-items:center; gap:10px; padding:8px 12px;
+                   background:var(--bg); border-bottom:1px solid var(--line); font-size:13px; }
+    .outcard .hd .sp { flex:1; }
+    .outcard pre { margin:0; padding:12px; max-height:280px; overflow:auto; font-size:12px;
+                   font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
+    .outcard .err { color:var(--err); padding:10px 12px; font-size:13px; }
   </style>
 </head>
 <body>
@@ -370,6 +377,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
           <span>Schedule: ${sched}</span> ${enBadge}
         </div>
         <div class="chartwrap"><canvas id="flow"></canvas><div id="fctip"></div></div>
+        <h3 style="margin:18px 0 8px; font-size:12px; text-transform:uppercase; color:var(--muted)">Run output</h3>
+        <div id="runOutput" class="muted">Run the job or pick a run below to see each step's output.</div>
         <h3 style="margin:18px 0 8px; font-size:12px; text-transform:uppercase; color:var(--muted)">Run history</h3>
         <div id="runs" class="muted">Loading runs...</div>`;
       $('runJob').onclick = ()=>runJob(j.id);
@@ -393,10 +402,35 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       } catch(e){ if(e.message!=='Unauthorized') toast('Toggle failed: '+e.message,'err'); }
     }
 
+    function fmtOutput(o){ try { return JSON.stringify(o, null, 2); } catch(e){ return String(o); } }
+
+    // Render each step's output (and error) for a run.
+    function renderRunOutput(run){
+      const el=$('runOutput'); if(!el) return;
+      const steps=Array.isArray(run.result)?run.result:[];
+      if(!steps.length){
+        el.innerHTML='<span class="muted">No step output for this run'+
+          (run.error?': '+esc(run.error):'')+'.</span>'; return;
+      }
+      const head=`<div class="muted" style="margin-bottom:8px">Run <code>${esc(run.id.slice(0,8))}</code>
+        · ${esc(run.trigger)} · <span class="badge ${esc(run.status)}">${esc(run.status)}</span>
+        · ${esc(run.started_at)}</div>`;
+      el.innerHTML=head+steps.map((s,i)=>{
+        const label='STEP '+(i+1)+(s.name?(' · '+esc(s.name)):'')+' · '+esc(s.command||'');
+        const st=s.success?'success':'failed';
+        const body=(!s.success && s.error_message)
+          ? `<div class="err">${esc(s.error_message)}</div>`+
+            (s.output!==undefined?`<pre>${esc(fmtOutput(s.output))}</pre>`:'')
+          : `<pre>${esc(fmtOutput(s.output))}</pre>`;
+        return `<div class="outcard"><div class="hd"><strong>${label}</strong>
+          <span class="sp"></span><span class="badge ${st}">${st}</span></div>${body}</div>`;
+      }).join('');
+    }
+
     async function runJob(id){
       try { const r=await api('/api/jobs/'+encodeURIComponent(id)+'/run',{method:'POST'});
         toast('Run '+r.status,(r.status==='success')?'ok':'err');
-        flow.applyRun(r); loadRuns(id);
+        flow.applyRun(r); renderRunOutput(r); loadRuns(id);
       } catch(e){ if(e.message!=='Unauthorized') toast('Run failed: '+e.message,'err'); }
     }
     async function delJob(j){
@@ -418,7 +452,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     }
     async function showRun(id){
       try { const r=await api('/api/runs/'+encodeURIComponent(id));
-        flow.applyRun(r);
+        flow.applyRun(r); renderRunOutput(r);
         toast('Loaded run '+r.id.slice(0,8)+' ('+r.status+')',(r.status==='success')?'ok':'err');
       } catch(e){ if(e.message!=='Unauthorized') toast(e.message,'err'); }
     }

--- a/src/orcha/agent/dashboard_embedded.hpp
+++ b/src/orcha/agent/dashboard_embedded.hpp
@@ -137,6 +137,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     .outcard pre { margin:0; padding:12px; max-height:280px; overflow:auto; font-size:12px;
                    font-family:ui-monospace,SFMono-Regular,Menlo,monospace; }
     .outcard .err { color:var(--err); padding:10px 12px; font-size:13px; }
+    .outcard.flash { box-shadow:0 0 0 2px var(--accent); transition:box-shadow .2s; }
+    .runrow.sel td { background:var(--bg); }
   </style>
 </head>
 <body>
@@ -334,7 +336,12 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     });
 
     // ================= Jobs =================
-    let jobs=[], currentJob=null;
+    let jobs=[], currentJob=null, selectedRunId=null;
+
+    function markSelectedRun(){
+      document.querySelectorAll('.runrow').forEach(tr =>
+        tr.classList.toggle('sel', tr.dataset.run===selectedRunId));
+    }
 
     async function loadJobs(){
       try { const d=await api('/api/jobs'); jobs=d.jobs||[];
@@ -350,6 +357,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     async function selectJob(id){
       try {
         currentJob = await api('/api/jobs/'+encodeURIComponent(id));
+        selectedRunId = null; // re-auto-select the latest run for this job
         document.querySelectorAll('.joblist .item').forEach(x =>
           x.classList.toggle('active', x.dataset.job===id));
         renderJobDetail();
@@ -422,7 +430,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
           ? `<div class="err">${esc(s.error_message)}</div>`+
             (s.output!==undefined?`<pre>${esc(fmtOutput(s.output))}</pre>`:'')
           : `<pre>${esc(fmtOutput(s.output))}</pre>`;
-        return `<div class="outcard"><div class="hd"><strong>${label}</strong>
+        return `<div class="outcard" id="out-step-${i}"><div class="hd"><strong>${label}</strong>
           <span class="sp"></span><span class="badge ${st}">${st}</span></div>${body}</div>`;
       }).join('');
     }
@@ -430,7 +438,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     async function runJob(id){
       try { const r=await api('/api/jobs/'+encodeURIComponent(id)+'/run',{method:'POST'});
         toast('Run '+r.status,(r.status==='success')?'ok':'err');
-        flow.applyRun(r); renderRunOutput(r); loadRuns(id);
+        selectedRunId=r.id; flow.applyRun(r); renderRunOutput(r); loadRuns(id);
       } catch(e){ if(e.message!=='Unauthorized') toast('Run failed: '+e.message,'err'); }
     }
     async function delJob(j){
@@ -444,14 +452,19 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     async function loadRuns(id){
       try { const d=await api('/api/jobs/'+encodeURIComponent(id)+'/runs?limit=20');
         const runs=d.runs||[];
+        // Auto-select the latest run (its full result is already in the list).
+        if(runs.length && (!selectedRunId || !runs.some(r=>r.id===selectedRunId))){
+          selectedRunId=runs[0].id; flow.applyRun(runs[0]); renderRunOutput(runs[0]);
+        }
         $('runs').innerHTML = runs.length ? `<table><thead><tr><th>Started</th><th>Trigger</th><th>Status</th></tr></thead>
-          <tbody>${runs.map(r=>`<tr class="runrow" data-run="${esc(r.id)}"><td>${esc(r.started_at)}</td>
+          <tbody>${runs.map(r=>`<tr class="runrow${r.id===selectedRunId?' sel':''}" data-run="${esc(r.id)}"><td>${esc(r.started_at)}</td>
             <td>${esc(r.trigger)}</td><td><span class="badge ${esc(r.status)}">${esc(r.status)}</span></td></tr>`).join('')}
           </tbody></table>` : '<span class="muted">No runs yet.</span>';
       } catch(e){ if(e.message!=='Unauthorized') $('runs').textContent='Failed to load runs.'; }
     }
     async function showRun(id){
       try { const r=await api('/api/runs/'+encodeURIComponent(id));
+        selectedRunId=id; markSelectedRun();
         flow.applyRun(r); renderRunOutput(r);
         toast('Loaded run '+r.id.slice(0,8)+' ('+r.status+')',(r.status==='success')?'ok':'err');
       } catch(e){ if(e.message!=='Unauthorized') toast(e.message,'err'); }
@@ -510,7 +523,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       const NODE_W=158, NODE_H=46, COL_GAP=66, ROW_GAP=22, PAD=20;
       let canvas=null, ctx=null, tip=null;
       let nodes=[], edges=[], job=null, runStatus=null; // runStatus: array of bool|null per step
-      let hover=-1, sel=-1, drag=-1, dragDX=0, dragDY=0, dpr=1;
+      let hover=-1, sel=-1, drag=-1, dragDX=0, dragDY=0, dpr=1, downX=0, downY=0;
+      let onSelect=null; // callback(stepIndex) on node click (not drag)
 
       function cssVar(n){ return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
 
@@ -608,7 +622,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       function bind(){
         canvas.addEventListener('mousedown', e=>{ const r=canvas.getBoundingClientRect();
           const mx=e.clientX-r.left, my=e.clientY-r.top; const i=hit(mx,my);
-          sel=i; if(i>=0){ drag=i; dragDX=mx-nodes[i].x; dragDY=my-nodes[i].y; } render(); });
+          sel=i; downX=e.clientX; downY=e.clientY;
+          if(i>=0){ drag=i; dragDX=mx-nodes[i].x; dragDY=my-nodes[i].y; } render(); });
         canvas.addEventListener('mousemove', e=>{ const r=canvas.getBoundingClientRect();
           const mx=e.clientX-r.left, my=e.clientY-r.top;
           if(drag>=0){ nodes[drag].x=mx-dragDX; nodes[drag].y=my-dragDY; render(); return; }
@@ -619,12 +634,17 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
             tip.textContent=(nd.name?('"'+nd.name+'"  '):'')+'step'+(i+1)+' · '+nd.cmd+'\n'+JSON.stringify(nd.params,null,1).slice(0,260);
           } else tip.style.display='none';
         });
-        window.addEventListener('mouseup', ()=>{ drag=-1; });
+        window.addEventListener('mouseup', e=>{
+          const moved = Math.abs(e.clientX-downX) + Math.abs(e.clientY-downY) > 4;
+          if(!moved && sel>=0 && onSelect) onSelect(sel); // click (not drag) -> jump to output
+          drag=-1;
+        });
         canvas.addEventListener('mouseleave', ()=>{ hover=-1; tip.style.display='none'; render(); });
       }
 
       return {
         get job(){ return job; },
+        setOnSelect(fn){ onSelect=fn; },
         setJob(j){ job=j; runStatus=null; sel=-1; hover=-1;
           canvas=$('flow'); ctx=canvas.getContext('2d'); tip=$('fctip');
           parse(j.definition); bind(); resize(); },
@@ -636,6 +656,15 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
         resize, render
       };
     })();
+
+    // Clicking a flow-chart node jumps to (and flashes) that step's output card.
+    flow.setOnSelect(function(i){
+      const card=document.getElementById('out-step-'+i);
+      if(!card) return;
+      card.scrollIntoView({behavior:'smooth', block:'center'});
+      card.classList.add('flash');
+      setTimeout(()=>card.classList.remove('flash'), 1200);
+    });
 
     // ---------- Boot ----------
     if(getAuth()) enterApp(); else showLogin();

--- a/src/orcha/agent/dashboard_embedded.hpp
+++ b/src/orcha/agent/dashboard_embedded.hpp
@@ -528,18 +528,18 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
         ctx.clearRect(0,0,canvas.width,canvas.height);
         const line=cssVar('--line'), fg=cssVar('--fg'), muted=cssVar('--muted'),
               panel=cssVar('--panel'), accent=cssVar('--accent');
-        // edges
-        ctx.lineWidth=1.5;
+        // edges (use --muted, not --line: --line is too faint against the chart bg)
+        ctx.lineWidth=2;
         edges.forEach(([a,b])=>{
           const na=nodes[a], nb=nodes[b];
           const x1=na.x+NODE_W, y1=na.y+NODE_H/2, x2=nb.x, y2=nb.y+NODE_H/2;
           const hl = (hover===a||hover===b||sel===a||sel===b);
-          ctx.strokeStyle = hl?accent:line;
+          ctx.strokeStyle = hl?accent:muted;
           ctx.beginPath(); ctx.moveTo(x1,y1);
           const mx=(x1+x2)/2; ctx.bezierCurveTo(mx,y1,mx,y2,x2,y2); ctx.stroke();
           // arrowhead (points left into the target node's left edge)
-          ctx.fillStyle=hl?accent:line;
-          ctx.beginPath(); ctx.moveTo(x2,y2); ctx.lineTo(x2-7,y2-4); ctx.lineTo(x2-7,y2+4); ctx.closePath(); ctx.fill();
+          ctx.fillStyle=hl?accent:muted;
+          ctx.beginPath(); ctx.moveTo(x2,y2); ctx.lineTo(x2-8,y2-5); ctx.lineTo(x2-8,y2+5); ctx.closePath(); ctx.fill();
         });
         // nodes
         nodes.forEach(nd=>{

--- a/src/orcha/agent/dashboard_embedded.hpp
+++ b/src/orcha/agent/dashboard_embedded.hpp
@@ -436,8 +436,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
     // ---------- Editor modal ----------
     let editingId=null;
     const DEFAULT_DEF = JSON.stringify({steps:[
-      {command:"echo", params:{message:"Hello from Orcha"}},
-      {command:"echo", params:{message:"step 1 said: {{step1.output.echoed}}"}}
+      {name:"greet", command:"echo", params:{message:"Hello from Orcha"}},
+      {name:"repeat", command:"echo", params:{message:"greet said: {{steps.greet.output.echoed}}"}}
     ]}, null, 2);
     function openEditor(job){
       editingId = job ? job.id : null;
@@ -483,11 +483,17 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       function parse(def){
         const steps=(def&&def.steps)||[];
         const n=steps.length;
+        const nameToIndex={};
+        for(let i=0;i<n;i++){ if(steps[i].name) nameToIndex[steps[i].name]=i; }
         const deps=Array.from({length:n},()=>new Set());
         for(let i=0;i<n;i++){
-          const s=JSON.stringify(steps[i].params||{});
-          const re=/\{\{\s*step(\d+)/g; let m;
+          const s=JSON.stringify(steps[i].params||{}); let m;
+          // positional {{stepN.output}}
+          const re=/\{\{\s*step(\d+)\b/g;
           while((m=re.exec(s))){ const k=parseInt(m[1],10)-1; if(k>=0&&k<n&&k!==i) deps[i].add(k); }
+          // named {{steps.<name>.output}}
+          const reN=/\{\{\s*steps\.([A-Za-z_]\w*)/g;
+          while((m=reN.exec(s))){ const k=nameToIndex[m[1]]; if(k!==undefined&&k!==i) deps[i].add(k); }
         }
         const level=new Array(n).fill(0);
         for(let it=0;it<n;it++) for(let i=0;i<n;i++) for(const d of deps[i]) level[i]=Math.max(level[i],level[d]+1);
@@ -495,7 +501,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
         for(let i=0;i<n;i++){
           const L=level[i]; rowOf[L]=(rowOf[L]||0);
           const row=rowOf[L]++;
-          nodes.push({ i, cmd:(steps[i].command||'?'), params:steps[i].params||{},
+          nodes.push({ i, name:(steps[i].name||''), cmd:(steps[i].command||'?'), params:steps[i].params||{},
             x:PAD+L*(NODE_W+COL_GAP), y:PAD+row*(NODE_H+ROW_GAP) });
         }
         for(let i=0;i<n;i++) for(const d of deps[i]) edges.push([d,i]);
@@ -553,7 +559,9 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
           ctx.lineWidth=(nd.i===sel||nd.i===hover)?2:1.2;
           ctx.strokeStyle=(nd.i===hover)?accent:c.stroke; ctx.stroke();
           ctx.fillStyle=muted; ctx.font='600 11px -apple-system,sans-serif';
-          ctx.fillText('STEP '+(nd.i+1), nd.x+12, nd.y+17);
+          let tag='STEP '+(nd.i+1)+(nd.name?(' · '+nd.name):'');
+          if(tag.length>22) tag=tag.slice(0,21)+'…';
+          ctx.fillText(tag, nd.x+12, nd.y+17);
           ctx.fillStyle=fg; ctx.font='13px -apple-system,sans-serif';
           let label=nd.cmd; if(label.length>18) label=label.slice(0,17)+'…';
           ctx.fillText(label, nd.x+12, nd.y+34);
@@ -574,7 +582,7 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
           if(i!==hover){ hover=i; canvas.style.cursor=i>=0?'grab':'default'; render(); }
           if(i>=0){ const nd=nodes[i];
             tip.style.display='block'; tip.style.left=(nd.x+NODE_W+8)+'px'; tip.style.top=nd.y+'px';
-            tip.textContent='step'+(i+1)+' · '+nd.cmd+'\n'+JSON.stringify(nd.params,null,1).slice(0,260);
+            tip.textContent=(nd.name?('"'+nd.name+'"  '):'')+'step'+(i+1)+' · '+nd.cmd+'\n'+JSON.stringify(nd.params,null,1).slice(0,260);
           } else tip.style.display='none';
         });
         window.addEventListener('mouseup', ()=>{ drag=-1; });

--- a/src/orcha/agent/dashboard_embedded.hpp
+++ b/src/orcha/agent/dashboard_embedded.hpp
@@ -206,6 +206,10 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       <div class="bd">
         <div class="field"><label>Name</label><input id="jName" type="text" style="width:100%" /></div>
         <div class="field"><label>Description</label><input id="jDesc" type="text" style="width:100%" /></div>
+        <div class="field"><label>Schedule (cron, optional &mdash; "m h dom mon dow")</label>
+          <input id="jSchedule" type="text" placeholder="e.g. 0 9 * * 1-5  (blank = manual only)" style="width:100%" /></div>
+        <div class="field"><label style="display:flex; align-items:center; gap:8px; color:var(--fg)">
+          <input id="jEnabled" type="checkbox" /> Enabled (the scheduler runs this job when due)</label></div>
         <div class="field"><label>Definition (JSON with a "steps" array)</label>
           <textarea id="jDef" spellcheck="false"></textarea></div>
         <div class="login-err" id="modalErr"></div>
@@ -330,7 +334,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
         $('jobsCount').textContent=jobs.length+' job(s)';
         $('jobItems').innerHTML = jobs.length ? jobs.map(j =>
           `<div class="item ${currentJob&&currentJob.id===j.id?'active':''}" data-job="${esc(j.id)}">
-             <div class="nm">${esc(j.name)}</div><div class="muted">${esc(j.description||'')}</div></div>`).join('')
+             <div class="nm">${esc(j.name)}${j.enabled?'':' <span class="muted">(disabled)</span>'}${j.schedule_cron?' <span class="muted">&#9201;</span>':''}</div>
+             <div class="muted">${esc(j.description||'')}</div></div>`).join('')
           : '<div class="pad muted">No jobs yet. Click "New job".</div>';
       } catch(e){ if(e.message!=='Unauthorized') toast('Failed to load jobs: '+e.message,'err'); }
     }
@@ -346,23 +351,46 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
 
     function renderJobDetail(){
       const j=currentJob; if(!j){ return; }
+      const sched = j.schedule_cron
+        ? `<code>${esc(j.schedule_cron)}</code>` : '<span class="muted">manual only</span>';
+      const enBadge = j.enabled
+        ? '<span class="badge success">enabled</span>'
+        : '<span class="badge failed">disabled</span>';
       $('jobDetail').innerHTML = `
         <div class="toolbar">
           <strong style="font-size:15px">${esc(j.name)}</strong>
           <span class="muted">${esc(j.description||'')}</span>
           <span style="margin-left:auto"></span>
           <button class="btn primary" id="runJob">Run now</button>
+          <button class="btn" id="toggleJob">${j.enabled ? 'Disable' : 'Enable'}</button>
           <button class="btn" id="editJob">Edit</button>
           <button class="btn danger" id="delJob">Delete</button>
+        </div>
+        <div class="muted" style="margin:-6px 0 12px; display:flex; gap:14px; align-items:center">
+          <span>Schedule: ${sched}</span> ${enBadge}
         </div>
         <div class="chartwrap"><canvas id="flow"></canvas><div id="fctip"></div></div>
         <h3 style="margin:18px 0 8px; font-size:12px; text-transform:uppercase; color:var(--muted)">Run history</h3>
         <div id="runs" class="muted">Loading runs...</div>`;
       $('runJob').onclick = ()=>runJob(j.id);
+      $('toggleJob').onclick = ()=>toggleJob(j);
       $('editJob').onclick = ()=>openEditor(j);
       $('delJob').onclick = ()=>delJob(j);
       flow.setJob(j);
       loadRuns(j.id);
+    }
+
+    async function toggleJob(j){
+      const payload = { name:j.name, description:j.description||'',
+                        definition:j.definition, enabled:!j.enabled };
+      if(j.schedule_cron) payload.schedule_cron = j.schedule_cron;
+      try {
+        await api('/api/jobs/'+encodeURIComponent(j.id),
+          {method:'PUT', headers:{'Content-Type':'application/json'}, body:JSON.stringify(payload)});
+        toast(j.enabled ? 'Disabled' : 'Enabled', 'ok');
+        await loadJobs();
+        await selectJob(j.id);
+      } catch(e){ if(e.message!=='Unauthorized') toast('Toggle failed: '+e.message,'err'); }
     }
 
     async function runJob(id){
@@ -416,6 +444,8 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       $('modalTitle').textContent = job ? 'Edit job' : 'New job';
       $('jName').value = job ? job.name : '';
       $('jDesc').value = job ? (job.description||'') : '';
+      $('jSchedule').value = (job && job.schedule_cron) ? job.schedule_cron : '';
+      $('jEnabled').checked = job ? !!job.enabled : true;
       $('jDef').value  = job ? JSON.stringify(job.definition, null, 2) : DEFAULT_DEF;
       $('modalErr').textContent='';
       $('modal').classList.add('show');
@@ -425,7 +455,10 @@ inline constexpr const char kDashboardHtml[] = R"HTML(<!DOCTYPE html>
       let def;
       try { def=JSON.parse($('jDef').value); }
       catch(e){ $('modalErr').textContent='Definition is not valid JSON: '+e.message; return; }
-      const payload={ name:$('jName').value.trim(), description:$('jDesc').value.trim(), definition:def };
+      const payload={ name:$('jName').value.trim(), description:$('jDesc').value.trim(),
+                      definition:def, enabled:$('jEnabled').checked };
+      const sched=$('jSchedule').value.trim();
+      if(sched) payload.schedule_cron=sched;   // omitted => cleared (manual only)
       if(!payload.name){ $('modalErr').textContent='Name is required.'; return; }
       try {
         if(editingId){ await api('/api/jobs/'+encodeURIComponent(editingId),

--- a/src/orcha/agent/routes/PluginAdminRoute.hpp
+++ b/src/orcha/agent/routes/PluginAdminRoute.hpp
@@ -14,6 +14,7 @@
 #include "../../core/PluginManager.hpp"
 #include "../../core/IPluginDiscovery.hpp"
 #include "../../core/ICommandRegistry.hpp"
+#include "../../core/PluginDenylist.hpp"
 #include "../../utils/ILogger.hpp"
 
 #include <chrono>
@@ -34,13 +35,15 @@ namespace Orcha::Agent::Routes {
                          std::shared_ptr<Core::ICommandRegistry> registry,
                          std::string plugin_directory,
                          std::chrono::milliseconds watch_interval,
-                         std::shared_ptr<Utils::ILogger> logger = nullptr)
+                         std::shared_ptr<Utils::ILogger> logger = nullptr,
+                         std::shared_ptr<Core::IPluginDenylist> denylist = nullptr)
             : manager_(std::move(manager))
             , discovery_(std::move(discovery))
             , registry_(std::move(registry))
             , directory_(std::move(plugin_directory))
             , watch_interval_(watch_interval)
-            , logger_(std::move(logger)) {}
+            , logger_(std::move(logger))
+            , denylist_(std::move(denylist)) {}
 
         [[nodiscard]] bool can_handle(
             const std::string& method,
@@ -116,6 +119,7 @@ namespace Orcha::Agent::Routes {
             auto discovery = discovery_;
             auto registry = registry_;
             auto directory = directory_;
+            auto denylist = denylist_;
 
             pplx::create_task([=]() {
                 using web::json::value;
@@ -131,10 +135,12 @@ namespace Orcha::Agent::Routes {
                     plugins[idx++] = plugin_to_json(meta, "loaded");
                 }
 
-                // Available-but-not-loaded from disk.
+                // Available-but-not-loaded from disk. Denylisted ones are tagged
+                // "disabled" (won't auto-load on restart) vs plain "available".
                 for (const auto& meta : discovery->scan_plugins(directory)) {
                     if (!loaded_names.contains(meta.name)) {
-                        plugins[idx++] = plugin_to_json(meta, "available");
+                        const bool denied = denylist && denylist->contains(meta.name);
+                        plugins[idx++] = plugin_to_json(meta, denied ? "disabled" : "available");
                     }
                 }
 
@@ -223,17 +229,20 @@ namespace Orcha::Agent::Routes {
             auto discovery = discovery_;
             auto directory = directory_;
             auto logger = logger_;
+            auto denylist = denylist_;
 
             pplx::create_task([=]() {
                 bool ok = false;
                 std::string message;
 
                 if (action == "reload") {
+                    // Reload does NOT touch the denylist.
                     ok = manager->reload_plugin(name);
                     message = ok ? "Reloaded " + name
                                  : "Reload failed; plugin not loaded: " + name;
                 } else if (action == "disable") {
                     ok = manager->unload_plugin(name);
+                    if (ok && denylist) denylist->add(name); // persist: stays off across restarts
                     message = ok ? "Disabled " + name
                                  : "Disable failed; plugin not loaded: " + name;
                 } else if (action == "enable") {
@@ -250,6 +259,7 @@ namespace Orcha::Agent::Routes {
                         return reply_error(request, web::http::status_codes::NotFound,
                                            "No available plugin named: " + name);
                     }
+                    if (denylist) denylist->remove(name); // clear persisted disable
                     ok = manager->load_plugin(lib_path);
                     message = ok ? "Enabled " + name
                                  : "Enable failed (already loaded or load error): " + name;
@@ -319,6 +329,7 @@ namespace Orcha::Agent::Routes {
         std::string directory_;
         std::chrono::milliseconds watch_interval_;
         std::shared_ptr<Utils::ILogger> logger_;
+        std::shared_ptr<Core::IPluginDenylist> denylist_;
     };
 
 } // namespace Orcha::Agent::Routes

--- a/src/orcha/config/YamlConfiguration.cpp
+++ b/src/orcha/config/YamlConfiguration.cpp
@@ -266,6 +266,8 @@ admin:
 
 jobs:
   db_path: "./orcha-jobs.db"
+  scheduler_enabled: true
+  scheduler_tick_seconds: 30
 )");
         config->merge_environment("ORCHA_");
         return config;

--- a/src/orcha/core/PluginDenylist.hpp
+++ b/src/orcha/core/PluginDenylist.hpp
@@ -1,0 +1,94 @@
+//
+// PluginDenylist.hpp - Persistent set of disabled plugin names (Phase 3).
+//
+// When a plugin is disabled through the admin API its name is added here and
+// persisted to a file, so it stays unloaded across restarts (the PluginManager
+// skips denylisted plugins when scanning the plugin directory). Enabling removes
+// it. Reload does NOT touch the denylist.
+//
+
+#pragma once
+
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace Orcha::Core {
+
+    /**
+     * @interface IPluginDenylist
+     * @brief Persistent set of plugin names that must not be auto-loaded.
+     */
+    class IPluginDenylist {
+    public:
+        virtual ~IPluginDenylist() = default;
+        [[nodiscard]] virtual bool contains(const std::string& name) const = 0;
+        virtual void add(const std::string& name) = 0;
+        virtual void remove(const std::string& name) = 0;
+        [[nodiscard]] virtual std::vector<std::string> list() const = 0;
+    };
+
+    /**
+     * @class FilePluginDenylist
+     * @brief File-backed IPluginDenylist (one plugin name per line).
+     */
+    class FilePluginDenylist : public IPluginDenylist {
+    public:
+        explicit FilePluginDenylist(std::filesystem::path path)
+            : path_(std::move(path)) {
+            load();
+        }
+
+        [[nodiscard]] bool contains(const std::string& name) const override {
+            std::lock_guard lock(mutex_);
+            return names_.count(name) > 0;
+        }
+
+        void add(const std::string& name) override {
+            std::lock_guard lock(mutex_);
+            if (names_.insert(name).second) save();
+        }
+
+        void remove(const std::string& name) override {
+            std::lock_guard lock(mutex_);
+            if (names_.erase(name) > 0) save();
+        }
+
+        [[nodiscard]] std::vector<std::string> list() const override {
+            std::lock_guard lock(mutex_);
+            return {names_.begin(), names_.end()};
+        }
+
+    private:
+        void load() {
+            std::ifstream in(path_);
+            if (!in) return;
+            std::string line;
+            while (std::getline(in, line)) {
+                // trim trailing CR/whitespace
+                while (!line.empty() &&
+                       (line.back() == '\r' || line.back() == ' ' || line.back() == '\t')) {
+                    line.pop_back();
+                }
+                if (!line.empty()) names_.insert(line);
+            }
+        }
+
+        void save() const {
+            std::error_code ec;
+            if (path_.has_parent_path()) {
+                std::filesystem::create_directories(path_.parent_path(), ec);
+            }
+            std::ofstream out(path_, std::ios::trunc);
+            for (const auto& n : names_) out << n << '\n';
+        }
+
+        std::filesystem::path path_;
+        mutable std::mutex mutex_;
+        std::set<std::string> names_;
+    };
+
+} // namespace Orcha::Core

--- a/src/orcha/core/PluginManager.cpp
+++ b/src/orcha/core/PluginManager.cpp
@@ -148,6 +148,20 @@ namespace Orcha::Core {
         logger_->info("Discovered " + std::to_string(plugins.size()) +
                      " plugin(s) in " + directory.string());
 
+        // Skip plugins on the persistent denylist (disabled via the admin API).
+        if (denylist_) {
+            std::erase_if(plugins, [this](const PluginMetadata& p) {
+                if (denylist_->contains(p.name)) {
+                    logger_->info("Skipping disabled plugin: " + p.name);
+                    return true;
+                }
+                return false;
+            });
+            if (plugins.empty()) {
+                return result;
+            }
+        }
+
         // Resolve dependencies and get load order
         auto resolve_result = DependencyResolver::resolve(plugins, strict_dependencies);
 

--- a/src/orcha/core/PluginManager.hpp
+++ b/src/orcha/core/PluginManager.hpp
@@ -8,6 +8,7 @@
 #include "IPluginDiscovery.hpp"
 #include "ICommandRegistry.hpp"
 #include "DependencyResolver.hpp"
+#include "PluginDenylist.hpp"
 #include "../utils/ILogger.hpp"
 #include <memory>
 #include <functional>
@@ -145,6 +146,14 @@ namespace Orcha::Core {
          */
         [[nodiscard]] bool is_watching() const { return watching_.load(); }
 
+        /**
+         * @brief Set the persistent denylist. Denylisted plugin names are skipped
+         *        when scanning a directory in load_plugins_from_directory.
+         */
+        void set_denylist(std::shared_ptr<IPluginDenylist> denylist) {
+            denylist_ = std::move(denylist);
+        }
+
         // Event callbacks
         void on_plugin_loaded(PluginCallback callback);
         void on_plugin_unloaded(PluginCallback callback);
@@ -159,6 +168,7 @@ namespace Orcha::Core {
         std::shared_ptr<IMutableCommandRegistry> registry_;
         std::shared_ptr<IPluginDiscovery> discovery_;
         std::shared_ptr<Utils::ILogger> logger_;
+        std::shared_ptr<IPluginDenylist> denylist_;
 
         mutable std::mutex mutex_;
         std::unordered_map<std::string, PluginMetadata> loaded_plugins_;

--- a/src/orcha/docs/dashboard-phase2.md
+++ b/src/orcha/docs/dashboard-phase2.md
@@ -122,6 +122,25 @@ walked multi-level paths. `{{job}}` is still not a placeholder (only
 `{{stepN.output…}}` is); the dashboard's New-job template was updated to a
 resolving example instead of the misleading `{{job}}`.
 
+### Named step references
+
+In addition to positional `{{stepN.output.<path>}}`, steps can be referenced by
+name: give a step a `name` and reference it as `{{steps.<name>.output.<path>}}`.
+This survives reordering. Positional refs still work; the `steps.` prefix avoids
+any clash with `stepN`. An unknown name resolves to empty (not an error).
+
+```json
+{ "steps": [
+  { "name": "fetch",  "command": "http_request", "params": { "url": "https://api.github.com/zen" } },
+  { "name": "report", "command": "echo", "params": { "message": "zen: {{steps.fetch.output.body}}" } }
+] }
+```
+
+Implementation: `WorkflowStepResult` carries the step `name`; the resolver does a
+second pass for the named form; the parallel dependency analyzer and the Canvas
+flow chart both map names to steps for edges. Example:
+`sample_workflows/http-named-steps.yaml`.
+
 ### Test-harness note
 
 `tests/JobStoreTests.hpp` uses `ORCHA_ASSERT` (always-on), not `<cassert>`'s

--- a/src/orcha/docs/dashboard-phase3.md
+++ b/src/orcha/docs/dashboard-phase3.md
@@ -1,0 +1,82 @@
+# Orcha Admin Dashboard — Phase 3 (scheduling + plugin denylist)
+
+Phase 3 adds cron scheduling for jobs, enable/disable controls, and a persistent
+plugin disabled-denylist. Builds on Phases 1-2.
+
+## Scope delivered
+
+- **Cron scheduler.** `JobScheduler` runs on a background thread, evaluating
+  enabled jobs with a `schedule_cron` each tick and firing those due in the
+  current UTC minute (de-duplicated per minute, trigger `schedule`).
+- **Cron parser.** `CronExpr` — hand-rolled 5-field parser/matcher (no new deps).
+- **Schedule + enable UI.** Job editor has a cron field and an Enabled toggle;
+  the detail view shows the schedule + status and a quick Disable/Enable button;
+  the job list marks disabled/scheduled jobs.
+- **Persistent plugin denylist.** Disabling a plugin records its name so it stays
+  unloaded across restarts; enabling clears it; reload does not touch it.
+
+## Cron (`CronExpr`)
+
+Fields: `minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6, Sun=0)`.
+Per field: `*`, `a`, `a-b`, `a-b/n`, `*/n`, and comma lists. `dow` also accepts 7
+for Sunday. Day-of-month / day-of-week use the classic rule: if BOTH are
+restricted, a tick matches when EITHER matches; otherwise they are ANDed.
+All matching is UTC.
+
+## Scheduler (`JobScheduler`)
+
+- Ticks every `jobs.scheduler_tick_seconds` (default 30; must be < 60 so no
+  minute is missed). Each tick reads jobs fresh, so edits are picked up live.
+- `evaluate(tm)` is public and pure (no threads/clock) for deterministic tests;
+  the thread calls it with the current UTC time.
+- De-dups by `(job id, "YYYY-MM-DDTHH:MM")` so a job fires at most once per minute.
+- Invalid cron expressions are warned once and skipped (not fatal).
+- Runs jobs synchronously through `JobService` (so runs are recorded and the
+  store's single-writer discipline holds). A slow job delays later jobs in the
+  same tick but they still fire with the correct minute key.
+
+Config:
+```yaml
+jobs:
+  scheduler_enabled: true
+  scheduler_tick_seconds: 30
+```
+The scheduler runs only in server mode and stops on shutdown.
+
+## Plugin denylist (`IPluginDenylist` / `FilePluginDenylist`)
+
+- File-backed (one plugin name per line) at `plugins.denylist_path`
+  (default `./orcha-disabled-plugins.txt`).
+- `PluginManager::load_plugins_from_directory` skips denylisted plugins (logged).
+- `PluginAdminRoute`: **disable** unloads + adds to the denylist; **enable**
+  removes from the denylist + loads; **reload** is unchanged. Available-on-disk
+  plugins that are denylisted report status `disabled` (vs `available`).
+
+## Wiring
+
+- `bootstrap_services` registers `IPluginDenylist` (FilePluginDenylist) and calls
+  `PluginManager::set_denylist` before plugins load.
+- `run_server_mode` builds + starts a `JobScheduler` (when a job service exists
+  and `scheduler_enabled`), and passes the denylist into `CommandAgent` →
+  `PluginAdminRoute`.
+- New cron/scheduler sources live in the `jobs` lib; `PluginDenylist.hpp` in `core`.
+
+## Tests
+
+- `tests/CronTests.hpp` — parser validation + matching (steps, lists, ranges,
+  weekday ranges, the dom/dow OR rule, Sunday 0/7, daily midnight).
+- `tests/JobStoreTests.hpp::test_scheduler_fires` — enabled vs disabled vs
+  not-due, per-minute de-dup, and that a fired run is recorded with trigger
+  `schedule` (drives `evaluate(tm)` directly — no sleeping).
+- `tests/PluginAdminTests.hpp::test_plugin_denylist` — add/remove/list + file
+  persistence across instances.
+
+Verified: Debug + Release build clean; unit tests pass in both; live checks
+confirm the background scheduler fires a `* * * * *` job and that a disabled
+plugin stays unloaded across a restart (and re-enabling restores it).
+
+## Known limitation
+
+Environment overrides via `merge_environment` map every `_` to `.`, so a leaf key
+containing underscores (e.g. `jobs.scheduler_tick_seconds`) cannot be set through
+`ORCHA_*` env vars — use the YAML config file for those. (Pre-existing behaviour.)

--- a/src/orcha/jobs/CronExpr.hpp
+++ b/src/orcha/jobs/CronExpr.hpp
@@ -1,0 +1,119 @@
+//
+// CronExpr.hpp - Minimal 5-field cron expression parser/matcher (Phase 3).
+//
+// Fields:  minute(0-59) hour(0-23) day-of-month(1-31) month(1-12) day-of-week(0-6, Sun=0)
+// Per field: '*', 'a', 'a-b', 'a-b/n', '*/n', and comma-separated lists thereof.
+// day-of-week also accepts 7 as Sunday.
+//
+// day-of-month / day-of-week follow the classic rule: if BOTH are restricted
+// (not '*'), a tick matches when EITHER matches; otherwise both are ANDed.
+//
+// All matching is done in UTC (the scheduler ticks in UTC).
+//
+
+#pragma once
+
+#include <array>
+#include <bitset>
+#include <ctime>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace Orcha::Jobs {
+
+    class CronExpr {
+    public:
+        /// Parse a 5-field cron string. Returns nullopt on malformed input.
+        [[nodiscard]] static std::optional<CronExpr> parse(const std::string& expr) {
+            std::vector<std::string> fields;
+            std::istringstream is(expr);
+            std::string tok;
+            while (is >> tok) fields.push_back(tok);
+            if (fields.size() != 5) return std::nullopt;
+
+            CronExpr c;
+            if (!parse_field(fields[0], 0, 59, c.minute_)) return std::nullopt;
+            if (!parse_field(fields[1], 0, 23, c.hour_))   return std::nullopt;
+            if (!parse_field(fields[2], 1, 31, c.dom_))    return std::nullopt;
+            if (!parse_field(fields[3], 1, 12, c.month_))  return std::nullopt;
+            if (!parse_field(fields[4], 0, 7,  c.dow_, /*dow=*/true)) return std::nullopt;
+            c.dom_star_ = (fields[2] == "*");
+            c.dow_star_ = (fields[4] == "*");
+            return c;
+        }
+
+        /// True if the given UTC broken-down time matches this expression.
+        [[nodiscard]] bool matches(const std::tm& t) const {
+            if (!minute_.test(t.tm_min)) return false;
+            if (!hour_.test(t.tm_hour)) return false;
+            if (!month_.test(t.tm_mon + 1)) return false; // tm_mon is 0-based
+
+            const bool dom_hit = dom_.test(t.tm_mday);
+            const bool dow_hit = dow_.test(t.tm_wday); // tm_wday: 0=Sun..6=Sat
+            const bool day_ok = (!dom_star_ && !dow_star_)
+                ? (dom_hit || dow_hit)   // both restricted -> OR
+                : (dom_hit && dow_hit);  // at least one '*' -> AND
+            return day_ok;
+        }
+
+    private:
+        // Bitsets sized to the max index+1 used by any field (dow uses 0..7).
+        std::bitset<60> minute_;
+        std::bitset<24> hour_;
+        std::bitset<32> dom_;
+        std::bitset<13> month_;
+        std::bitset<8>  dow_;
+        bool dom_star_ = true;
+        bool dow_star_ = true;
+
+        template <size_t N>
+        static bool set_bit(std::bitset<N>& bs, int v, bool dow) {
+            if (dow && v == 7) v = 0;            // Sunday alias
+            if (v < 0 || v >= static_cast<int>(N)) return false;
+            bs.set(static_cast<size_t>(v));
+            return true;
+        }
+
+        /// Parse one field (comma list of *, a, a-b, a-b/n, */n) into a bitset.
+        template <size_t N>
+        static bool parse_field(const std::string& field, int lo, int hi,
+                                std::bitset<N>& out, bool dow = false) {
+            std::istringstream is(field);
+            std::string part;
+            while (std::getline(is, part, ',')) {
+                if (part.empty()) return false;
+
+                int step = 1;
+                std::string range = part;
+                if (auto slash = part.find('/'); slash != std::string::npos) {
+                    range = part.substr(0, slash);
+                    try { step = std::stoi(part.substr(slash + 1)); }
+                    catch (...) { return false; }
+                    if (step <= 0) return false;
+                }
+
+                int start, end;
+                if (range == "*") {
+                    start = lo; end = hi;
+                } else if (auto dash = range.find('-'); dash != std::string::npos) {
+                    try { start = std::stoi(range.substr(0, dash));
+                          end   = std::stoi(range.substr(dash + 1)); }
+                    catch (...) { return false; }
+                } else {
+                    try { start = end = std::stoi(range); }
+                    catch (...) { return false; }
+                }
+                if (start > end) return false;
+                if (start < lo || end > hi) return false;
+
+                for (int v = start; v <= end; v += step) {
+                    if (!set_bit(out, v, dow)) return false;
+                }
+            }
+            return true;
+        }
+    };
+
+} // namespace Orcha::Jobs

--- a/src/orcha/jobs/JobScheduler.cpp
+++ b/src/orcha/jobs/JobScheduler.cpp
@@ -1,0 +1,116 @@
+//
+// JobScheduler.cpp - Cron-driven background scheduler (Phase 3)
+//
+
+#include "JobScheduler.hpp"
+#include "CronExpr.hpp"
+
+namespace Orcha::Jobs {
+
+    namespace {
+        std::string minute_key(const std::tm& t) {
+            char buf[20];
+            std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M", &t);
+            return buf;
+        }
+    }
+
+    JobScheduler::JobScheduler(std::shared_ptr<JobService> service,
+                               std::shared_ptr<Utils::ILogger> logger,
+                               std::chrono::seconds tick)
+        : service_(std::move(service))
+        , logger_(std::move(logger))
+        , tick_(tick.count() > 0 ? tick : std::chrono::seconds(30)) {}
+
+    JobScheduler::~JobScheduler() {
+        stop();
+    }
+
+    void JobScheduler::start() {
+        if (running_.exchange(true)) {
+            return; // already running
+        }
+        thread_ = std::thread(&JobScheduler::loop, this);
+        if (logger_) {
+            logger_->info("Job scheduler started (tick " +
+                          std::to_string(tick_.count()) + "s)");
+        }
+    }
+
+    void JobScheduler::stop() {
+        if (!running_.exchange(false)) {
+            return;
+        }
+        if (thread_.joinable()) {
+            thread_.join();
+        }
+        if (logger_) logger_->info("Job scheduler stopped");
+    }
+
+    void JobScheduler::loop() {
+        while (running_.load()) {
+            // Sleep up to tick_ seconds, but wake promptly on stop().
+            for (long i = 0; i < tick_.count() && running_.load(); ++i) {
+                std::this_thread::sleep_for(std::chrono::seconds(1));
+            }
+            if (!running_.load()) break;
+
+            std::time_t now = std::time(nullptr);
+            std::tm utc{};
+#if defined(_WIN32)
+            gmtime_s(&utc, &now);
+#else
+            gmtime_r(&now, &utc);
+#endif
+            try {
+                evaluate(utc);
+            } catch (const std::exception& ex) {
+                if (logger_) logger_->error(std::string("Scheduler tick error: ") + ex.what());
+            }
+        }
+    }
+
+    size_t JobScheduler::evaluate(const std::tm& now_utc) {
+        const std::string key = minute_key(now_utc);
+        size_t fired = 0;
+
+        for (const auto& job : service_->store()->list_jobs()) {
+            if (!job.enabled || !job.schedule_cron || job.schedule_cron->empty()) {
+                continue;
+            }
+
+            auto cron = CronExpr::parse(*job.schedule_cron);
+            if (!cron) {
+                std::lock_guard lock(mutex_);
+                if (warned_bad_cron_.insert(job.id).second && logger_) {
+                    logger_->warn("Job '" + job.name + "' has an invalid cron expression: " +
+                                  *job.schedule_cron);
+                }
+                continue;
+            }
+            {
+                std::lock_guard lock(mutex_);
+                warned_bad_cron_.erase(job.id); // expression may have been fixed
+            }
+
+            if (!cron->matches(now_utc)) {
+                continue;
+            }
+
+            {
+                std::lock_guard lock(mutex_);
+                auto it = last_fired_.find(job.id);
+                if (it != last_fired_.end() && it->second == key) {
+                    continue; // already fired this minute
+                }
+                last_fired_[job.id] = key;
+            }
+
+            if (logger_) logger_->info("Scheduler firing job '" + job.name + "' (" + key + ")");
+            (void)service_->run_job(job.id, "schedule");
+            ++fired;
+        }
+        return fired;
+    }
+
+} // namespace Orcha::Jobs

--- a/src/orcha/jobs/JobScheduler.hpp
+++ b/src/orcha/jobs/JobScheduler.hpp
@@ -1,0 +1,64 @@
+//
+// JobScheduler.hpp - Cron-driven background scheduler for jobs (Phase 3).
+//
+// Ticks on a background thread; on each tick it evaluates every enabled job
+// that has a schedule_cron and fires those whose expression matches the current
+// UTC minute (de-duplicated so a job fires at most once per minute).
+//
+
+#pragma once
+
+#include "JobService.hpp"
+#include "../utils/ILogger.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <ctime>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+
+namespace Orcha::Jobs {
+
+    class JobScheduler {
+    public:
+        JobScheduler(std::shared_ptr<JobService> service,
+                     std::shared_ptr<Utils::ILogger> logger,
+                     std::chrono::seconds tick = std::chrono::seconds(30));
+        ~JobScheduler();
+
+        JobScheduler(const JobScheduler&) = delete;
+        JobScheduler& operator=(const JobScheduler&) = delete;
+
+        void start();
+        void stop();
+        [[nodiscard]] bool is_running() const { return running_.load(); }
+
+        /**
+         * @brief Evaluate all jobs against @p now_utc and fire those that are due.
+         * @return Number of jobs fired this evaluation.
+         *
+         * Public for testability; also called by the background thread each tick.
+         * A job fires at most once per (job, minute) via internal de-duplication.
+         */
+        size_t evaluate(const std::tm& now_utc);
+
+    private:
+        void loop();
+
+        std::shared_ptr<JobService> service_;
+        std::shared_ptr<Utils::ILogger> logger_;
+        std::chrono::seconds tick_;
+
+        std::atomic<bool> running_{false};
+        std::thread thread_;
+
+        std::mutex mutex_;
+        std::unordered_map<std::string, std::string> last_fired_; // job id -> "YYYY-MM-DDTHH:MM"
+        std::unordered_set<std::string> warned_bad_cron_;          // jobs with an unparseable cron
+    };
+
+} // namespace Orcha::Jobs

--- a/src/orcha/main.cpp
+++ b/src/orcha/main.cpp
@@ -9,6 +9,7 @@
 // Core
 #include "core/CommandRegistry.hpp"
 #include "core/PluginManager.hpp"
+#include "core/PluginDenylist.hpp"
 #include "core/ServiceLocator.hpp"
 
 // Config
@@ -24,6 +25,7 @@
 #include "jobs/SqliteJobStore.hpp"
 #include "jobs/JobService.hpp"
 #include "jobs/RunJobCommand.hpp"
+#include "jobs/JobScheduler.hpp"
 
 // Utils
 #include "utils/Logger.hpp"
@@ -62,6 +64,12 @@ void bootstrap_services(Orcha::Core::ServiceLocator& services,
     auto plugin_manager = std::make_shared<Core::PluginManager>(
         registry, discovery, logger_ptr);
     services.register_singleton<Core::PluginManager>(plugin_manager);
+
+    // Persistent plugin denylist: disabled plugins stay unloaded across restarts.
+    auto denylist = std::make_shared<Core::FilePluginDenylist>(
+        config.get_string("plugins.denylist_path", "./orcha-disabled-plugins.txt"));
+    services.register_singleton<Core::IPluginDenylist>(denylist);
+    plugin_manager->set_denylist(denylist);
 
     // Workflow Engine (factory - creates new instances)
     auto engine_factory = [registry, logger_ptr]() {
@@ -204,6 +212,7 @@ int run_server_mode(Orcha::Core::ServiceLocator& services,
     auto plugins = services.get<Core::PluginManager>();
     auto discovery = services.get<Core::IPluginDiscovery>();
     auto job_service = services.try_get<Jobs::JobService>(); // may be null if store failed
+    auto denylist = services.try_get<Core::IPluginDenylist>();
 
     // Create agent with injected dependencies (including the admin dashboard).
     Agent::CommandAgent agent(
@@ -211,9 +220,19 @@ int run_server_mode(Orcha::Core::ServiceLocator& services,
         plugins, discovery, admin_config,
         plugin_config.directory,
         std::chrono::milliseconds(plugin_config.scan_interval_ms),
-        job_service);
+        job_service, denylist);
 
     agent.start(server_config.port);
+
+    // Cron scheduler (Phase 3): fire enabled jobs whose schedule_cron is due.
+    std::unique_ptr<Jobs::JobScheduler> scheduler;
+    const bool scheduler_enabled = config.get_bool("jobs.scheduler_enabled", true);
+    const auto scheduler_tick =
+        std::chrono::seconds(config.get_int("jobs.scheduler_tick_seconds", 30));
+    if (job_service && scheduler_enabled) {
+        scheduler = std::make_unique<Jobs::JobScheduler>(job_service, logger, scheduler_tick);
+        scheduler->start();
+    }
 
     const bool admin_on = admin_config.is_serviceable();
 
@@ -234,11 +253,16 @@ int run_server_mode(Orcha::Core::ServiceLocator& services,
     } else {
         std::cout << "  (admin dashboard disabled - see logs)\n";
     }
+    if (scheduler) {
+        std::cout << "  [scheduler] cron scheduling active (tick "
+                  << scheduler_tick.count() << "s)\n";
+    }
     std::cout << "[Orcha] Press Enter to exit...\n";
 
     std::cin.get();
 
     logger->info("Shutting down Orcha...");
+    if (scheduler) scheduler->stop();
     agent.stop();
 
     std::cout << "[Orcha] Shutdown complete.\n";

--- a/src/orcha/orcha.yaml.example
+++ b/src/orcha/orcha.yaml.example
@@ -16,6 +16,7 @@ plugins:
   directory: "./commands"
   auto_reload: false
   scan_interval_ms: 5000
+  denylist_path: "./orcha-disabled-plugins.txt"   # plugins disabled via the admin UI
 
 # Admin dashboard (/admin) and admin API (/api/plugins).
 admin:
@@ -27,6 +28,8 @@ admin:
   password: "change-me"
   realm: "Orcha Admin"
 
-# Jobs: saved workflows + run history (SQLite-backed).
+# Jobs: saved workflows + run history (SQLite-backed) + cron scheduler.
 jobs:
   db_path: "./orcha-jobs.db"
+  scheduler_enabled: true       # run due jobs (schedule_cron) on a timer
+  scheduler_tick_seconds: 30    # how often the scheduler checks (< 60)

--- a/src/orcha/sample_workflows/http-named-steps.yaml
+++ b/src/orcha/sample_workflows/http-named-steps.yaml
@@ -1,0 +1,29 @@
+name: http-named-steps
+description: >
+  HTTP request flow using NAMED step references ({{steps.<name>.output.<path>}})
+  instead of positional ({{stepN.output...}}), so reordering steps won't break
+  references. Run from the dashboard (Jobs -> New job, paste the JSON form) or:
+  ./orcha sample_workflows/http-named-steps.yaml
+
+steps:
+  # Fetch a small text endpoint. The step is named "fetch" so later steps can
+  # reference it by name rather than position.
+  - name: fetch
+    command: http_request
+    params:
+      url: "https://api.github.com/zen"
+      method: GET
+      timeout_ms: 5000
+
+  # Reference the fetch step BY NAME. http_request returns
+  # { success, status_code, body, headers }.
+  - name: report
+    command: echo
+    params:
+      message: "GitHub zen says: {{steps.fetch.output.body}} (HTTP {{steps.fetch.output.status_code}})"
+
+  # Named references also compose: this reads the previous "report" step's output.
+  - name: confirm
+    command: echo
+    params:
+      message: "reported -> {{steps.report.output.echoed}}"

--- a/src/orcha/tests/CronTests.hpp
+++ b/src/orcha/tests/CronTests.hpp
@@ -1,0 +1,102 @@
+//
+// CronTests.hpp - Tests for the CronExpr parser/matcher (Phase 3)
+//
+
+#pragma once
+
+#include "Assertions.hpp"
+#include "../jobs/CronExpr.hpp"
+#include <ctime>
+#include <iostream>
+
+namespace Orcha::Tests {
+
+    // Build a UTC broken-down time (with tm_wday filled in) from components.
+    inline std::tm cron_utc(int y, int mo, int d, int h, int mi) {
+        std::tm t{};
+        t.tm_year = y - 1900; t.tm_mon = mo - 1; t.tm_mday = d;
+        t.tm_hour = h; t.tm_min = mi; t.tm_sec = 0;
+        time_t e = timegm(&t);
+        std::tm out{};
+        gmtime_r(&e, &out);
+        return out;
+    }
+
+    inline void test_cron_parse_invalid() {
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("* * * *"));        // 4 fields
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("* * * * * *"));    // 6 fields
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("60 * * * *"));     // minute out of range
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("* 24 * * *"));     // hour out of range
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("x * * * *"));      // not a number
+        ORCHA_ASSERT(!Jobs::CronExpr::parse("*/0 * * * *"));    // zero step
+        ORCHA_ASSERT(!Jobs::CronExpr::parse(""));               // empty
+        ORCHA_ASSERT(Jobs::CronExpr::parse("* * * * *").has_value());
+        std::cout << "[PASS] test_cron_parse_invalid\n";
+    }
+
+    inline void test_cron_every_minute() {
+        auto c = Jobs::CronExpr::parse("* * * * *").value();
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 1, 0, 0)));
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 7, 4, 13, 37)));
+        std::cout << "[PASS] test_cron_every_minute\n";
+    }
+
+    inline void test_cron_step_and_list() {
+        auto c = Jobs::CronExpr::parse("*/15 * * * *").value();
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 1, 0, 0)));
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 1, 0, 15)));
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 1, 0, 45)));
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 1, 1, 0, 7)));
+
+        auto r = Jobs::CronExpr::parse("1-10/3 * * * *").value(); // 1,4,7,10
+        ORCHA_ASSERT(r.matches(cron_utc(2024, 1, 1, 0, 4)));
+        ORCHA_ASSERT(r.matches(cron_utc(2024, 1, 1, 0, 10)));
+        ORCHA_ASSERT(!r.matches(cron_utc(2024, 1, 1, 0, 5)));
+
+        auto l = Jobs::CronExpr::parse("0,30 * * * *").value();
+        ORCHA_ASSERT(l.matches(cron_utc(2024, 1, 1, 0, 30)));
+        ORCHA_ASSERT(!l.matches(cron_utc(2024, 1, 1, 0, 31)));
+        std::cout << "[PASS] test_cron_step_and_list\n";
+    }
+
+    inline void test_cron_weekday_range() {
+        // 09:30 on weekdays (Mon-Fri). 2024-01-01 is a Monday; 2024-01-06 a Saturday.
+        auto c = Jobs::CronExpr::parse("30 9 * * 1-5").value();
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 1, 9, 30)));   // Mon
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 1, 6, 9, 30)));  // Sat
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 1, 1, 9, 31)));  // wrong minute
+        std::cout << "[PASS] test_cron_weekday_range\n";
+    }
+
+    inline void test_cron_dom_dow_or_rule() {
+        // Both day-of-month(13) and day-of-week(Fri=5) restricted -> OR.
+        auto c = Jobs::CronExpr::parse("0 12 13 * 5").value();
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 13, 12, 0))); // 13th (Sat) -> dom hit
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 1, 12, 12, 0))); // Fri, not 13th -> dow hit
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 1, 14, 12, 0))); // Sun, not 13th -> neither
+
+        // Sunday via both 0 and 7.
+        ORCHA_ASSERT(Jobs::CronExpr::parse("0 0 * * 0").value().matches(cron_utc(2024, 1, 7, 0, 0)));
+        ORCHA_ASSERT(Jobs::CronExpr::parse("0 0 * * 7").value().matches(cron_utc(2024, 1, 7, 0, 0)));
+        std::cout << "[PASS] test_cron_dom_dow_or_rule\n";
+    }
+
+    inline void test_cron_midnight_daily() {
+        auto c = Jobs::CronExpr::parse("0 0 * * *").value();
+        ORCHA_ASSERT(c.matches(cron_utc(2024, 3, 15, 0, 0)));
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 3, 15, 0, 1)));
+        ORCHA_ASSERT(!c.matches(cron_utc(2024, 3, 15, 1, 0)));
+        std::cout << "[PASS] test_cron_midnight_daily\n";
+    }
+
+    inline void run_cron_tests() {
+        std::cout << "\n-- Cron (Phase 3) --\n";
+        test_cron_parse_invalid();
+        test_cron_every_minute();
+        test_cron_step_and_list();
+        test_cron_weekday_range();
+        test_cron_dom_dow_or_rule();
+        test_cron_midnight_daily();
+    }
+
+} // namespace Orcha::Tests

--- a/src/orcha/tests/JobStoreTests.hpp
+++ b/src/orcha/tests/JobStoreTests.hpp
@@ -16,11 +16,13 @@
 #include "../jobs/SqliteJobStore.hpp"
 #include "../jobs/JobService.hpp"
 #include "../jobs/RunJobCommand.hpp"
+#include "../jobs/JobScheduler.hpp"
 #include "../agent/routes/JobRoute.hpp"
 #include "../core/CommandRegistry.hpp"
 #include "../workflow/WorkflowEngine.hpp"
 #include "mocks/MockCommandRegistry.hpp"
 
+#include <ctime>
 #include <iostream>
 
 namespace Orcha::Tests {
@@ -167,6 +169,50 @@ namespace Orcha::Tests {
         std::cout << "[PASS] test_run_job_linking\n";
     }
 
+    inline void test_scheduler_fires() {
+        auto store = std::make_shared<Jobs::SqliteJobStore>(":memory:");
+        auto registry = std::make_shared<Core::CommandRegistry>();
+        ORCHA_ASSERT(registry->register_command(std::make_shared<Mocks::MockCommand>("echo",
+            [](const web::json::value&){ return web::json::value::object(); })));
+        auto factory = [registry]() -> std::shared_ptr<Workflow::IWorkflowEngine> {
+            return std::make_shared<Workflow::WorkflowEngine>(
+                registry, std::make_shared<Workflow::SyncStepExecutor>(), nullptr);
+        };
+        auto service = std::make_shared<Jobs::JobService>(store, factory, nullptr);
+
+        const auto def = web::json::value::parse(utility::conversions::to_string_t(
+            R"({"steps":[{"command":"echo","params":{}}]})"));
+
+        Jobs::JobDefinition on;   on.name = "tick"; on.enabled = true;
+        on.schedule_cron = "* * * * *"; on.definition = def;
+        ORCHA_ASSERT(store->create_job(on));
+
+        Jobs::JobDefinition off;  off.name = "off"; off.enabled = false;  // disabled
+        off.schedule_cron = "* * * * *"; off.definition = def;
+        ORCHA_ASSERT(store->create_job(off));
+
+        Jobs::JobDefinition noon; noon.name = "noon"; noon.enabled = true;
+        noon.schedule_cron = "0 12 * * *"; noon.definition = def;
+        ORCHA_ASSERT(store->create_job(noon));
+
+        Jobs::JobScheduler sched(service, nullptr, std::chrono::seconds(30));
+
+        auto utc = [](int y,int mo,int d,int h,int mi){
+            std::tm t{}; t.tm_year=y-1900; t.tm_mon=mo-1; t.tm_mday=d; t.tm_hour=h; t.tm_min=mi;
+            time_t e = timegm(&t); std::tm o{}; gmtime_r(&e,&o); return o; };
+
+        // 00:00 -> only "tick" (enabled, matches); "off" disabled; "noon" not due.
+        ORCHA_ASSERT(sched.evaluate(utc(2024,1,1,0,0)) == 1);
+        ORCHA_ASSERT(sched.evaluate(utc(2024,1,1,0,0)) == 0);   // de-duped within the minute
+        ORCHA_ASSERT(sched.evaluate(utc(2024,1,1,0,1)) == 1);   // new minute -> fires again
+        ORCHA_ASSERT(sched.evaluate(utc(2024,1,1,12,0)) == 2);  // "tick" + "noon"
+
+        auto runs = store->list_runs(on.id, 10);
+        ORCHA_ASSERT(!runs.empty() && runs[0].trigger == "schedule");
+
+        std::cout << "[PASS] test_scheduler_fires\n";
+    }
+
     inline void run_job_store_tests() {
         std::cout << "\n-- Jobs (Phase 2) --\n";
         test_job_store_crud();
@@ -174,6 +220,7 @@ namespace Orcha::Tests {
         test_job_store_runs();
         test_job_route_can_handle();
         test_run_job_linking();
+        test_scheduler_fires();
     }
 
 } // namespace Orcha::Tests

--- a/src/orcha/tests/JobStoreTests.hpp
+++ b/src/orcha/tests/JobStoreTests.hpp
@@ -213,6 +213,43 @@ namespace Orcha::Tests {
         std::cout << "[PASS] test_scheduler_fires\n";
     }
 
+    inline void test_named_step_reference() {
+        auto registry = std::make_shared<Core::CommandRegistry>();
+        // echo returns { echoed: <message> }
+        ORCHA_ASSERT(registry->register_command(std::make_shared<Mocks::MockCommand>("echo",
+            [](const web::json::value& p){
+                web::json::value o = web::json::value::object();
+                o[U("echoed")] = p.has_field(U("message"))
+                    ? p.at(U("message")) : web::json::value::string(U(""));
+                return o;
+            })));
+
+        Workflow::WorkflowEngine engine(
+            registry, std::make_shared<Workflow::SyncStepExecutor>(), nullptr);
+
+        // step 2 references step 1 BY NAME ("greet"), not by position.
+        auto def = Workflow::WorkflowDefinition::from_json(
+            web::json::value::parse(utility::conversions::to_string_t(
+                R"({"steps":[)"
+                R"({"name":"greet","command":"echo","params":{"message":"hi"}},)"
+                R"({"command":"echo","params":{"message":"got {{steps.greet.output.echoed}}"}}]})")));
+
+        auto res = engine.execute(def);
+        ORCHA_ASSERT(res.success);
+        ORCHA_ASSERT(res.step_results.size() == 2);
+        ORCHA_ASSERT(res.step_results[1].output.at(U("echoed")).as_string() == U("got hi"));
+
+        // A reference to an unknown step name resolves to empty (not an error).
+        auto def2 = Workflow::WorkflowDefinition::from_json(
+            web::json::value::parse(utility::conversions::to_string_t(
+                R"({"steps":[{"command":"echo","params":{"message":"x {{steps.nope.output.echoed}}"}}]})")));
+        auto res2 = engine.execute(def2);
+        ORCHA_ASSERT(res2.success);
+        ORCHA_ASSERT(res2.step_results[0].output.at(U("echoed")).as_string() == U("x "));
+
+        std::cout << "[PASS] test_named_step_reference\n";
+    }
+
     inline void run_job_store_tests() {
         std::cout << "\n-- Jobs (Phase 2) --\n";
         test_job_store_crud();
@@ -220,6 +257,7 @@ namespace Orcha::Tests {
         test_job_store_runs();
         test_job_route_can_handle();
         test_run_job_linking();
+        test_named_step_reference();
         test_scheduler_fires();
     }
 

--- a/src/orcha/tests/NewFeaturesTests.hpp
+++ b/src/orcha/tests/NewFeaturesTests.hpp
@@ -14,6 +14,7 @@
 #include "Assertions.hpp"
 #include "PluginAdminTests.hpp"
 #include "JobStoreTests.hpp"
+#include "CronTests.hpp"
 #include <iostream>
 #include <thread>
 #include <chrono>
@@ -373,6 +374,9 @@ server:
 
         // Jobs (Phase 2)
         run_job_store_tests();
+
+        // Cron (Phase 3)
+        run_cron_tests();
 
         std::cout << "\n=== All New Features Tests Passed ===\n";
     }

--- a/src/orcha/tests/PluginAdminTests.hpp
+++ b/src/orcha/tests/PluginAdminTests.hpp
@@ -13,8 +13,10 @@
 #include "../agent/IRouteHandler.hpp"
 #include "../agent/routes/PluginAdminRoute.hpp"
 #include "../config/AdminConfig.hpp"
+#include "../core/PluginDenylist.hpp"
 
 #include "Assertions.hpp"
+#include <cstdio>
 #include <iostream>
 
 namespace Orcha::Tests {
@@ -144,6 +146,29 @@ namespace Orcha::Tests {
         std::cout << "[PASS] test_plugin_route_can_handle\n";
     }
 
+    // ========== Plugin denylist (Phase 3) ==========
+
+    inline void test_plugin_denylist() {
+        const std::string path = "/tmp/orcha_test_denylist.txt";
+        std::remove(path.c_str());
+        {
+            Core::FilePluginDenylist d(path);
+            ORCHA_ASSERT(!d.contains("a"));
+            d.add("a"); d.add("b"); d.add("a"); // idempotent
+            ORCHA_ASSERT(d.contains("a") && d.contains("b"));
+            ORCHA_ASSERT(d.list().size() == 2);
+            d.remove("a");
+            ORCHA_ASSERT(!d.contains("a") && d.contains("b"));
+        }
+        // A fresh instance must read the persisted file.
+        {
+            Core::FilePluginDenylist d2(path);
+            ORCHA_ASSERT(d2.contains("b") && !d2.contains("a"));
+        }
+        std::remove(path.c_str());
+        std::cout << "[PASS] test_plugin_denylist\n";
+    }
+
     // ========== Runner ==========
 
     inline void run_plugin_admin_tests() {
@@ -155,6 +180,7 @@ namespace Orcha::Tests {
         test_admin_config_serviceable();
         test_path_helpers();
         test_plugin_route_can_handle();
+        test_plugin_denylist();
     }
 
 } // namespace Orcha::Tests

--- a/src/orcha/workflow/IWorkflowEngine.hpp
+++ b/src/orcha/workflow/IWorkflowEngine.hpp
@@ -25,6 +25,7 @@ namespace Orcha::Workflow {
         std::string error_message;
         web::json::value output;
         std::string command_name;
+        std::string name;          // Optional step name (for {{steps.<name>.output}} refs)
         int step_index = -1;
 
         [[nodiscard]] web::json::value to_json() const {
@@ -34,6 +35,9 @@ namespace Orcha::Workflow {
             obj[U("output")] = output;
             if (!command_name.empty()) {
                 obj[U("command")] = web::json::value::string(command_name);
+            }
+            if (!name.empty()) {
+                obj[U("name")] = web::json::value::string(name);
             }
             if (step_index >= 0) {
                 obj[U("step")] = web::json::value::number(step_index);

--- a/src/orcha/workflow/ParallelWorkflowExecutor.hpp
+++ b/src/orcha/workflow/ParallelWorkflowExecutor.hpp
@@ -64,24 +64,38 @@ namespace Orcha::Workflow {
                 deps[static_cast<int>(i)] = {static_cast<int>(i), {}, {}, 0};
             }
 
-            // Find dependencies based on placeholder references
+            // Map step name -> index, for named references.
+            std::unordered_map<std::string, int> name_to_index;
+            for (size_t i = 0; i < definition.steps.size(); ++i) {
+                if (definition.steps[i].name) {
+                    name_to_index[*definition.steps[i].name] = static_cast<int>(i);
+                }
+            }
+
+            // Find dependencies based on placeholder references, both positional
+            // ({{stepN.output}}) and named ({{steps.<name>.output}}).
             static const std::regex placeholder_regex(R"(\{\{step(\d+)\.output)");
+            static const std::regex named_regex(R"(\{\{steps\.([A-Za-z_][\w]*)\.output)");
+
+            auto add_dep = [&](size_t i, int ref) {
+                if (ref >= 0 && ref < static_cast<int>(i)) {
+                    deps[static_cast<int>(i)].depends_on.insert(ref);
+                    deps[ref].dependents.insert(static_cast<int>(i));
+                    deps[static_cast<int>(i)].in_degree++;
+                }
+            };
 
             for (size_t i = 0; i < definition.steps.size(); ++i) {
                 const auto& step = definition.steps[i];
-                auto referenced_steps = find_referenced_steps(step.params, placeholder_regex);
 
-                for (int ref : referenced_steps) {
-                    if (ref >= 0 && ref < static_cast<int>(i)) {
-                        // Step i depends on step ref
-                        deps[static_cast<int>(i)].depends_on.insert(ref);
-                        deps[ref].dependents.insert(static_cast<int>(i));
-                        deps[static_cast<int>(i)].in_degree++;
+                for (int ref : find_referenced_steps(step.params, placeholder_regex)) {
+                    add_dep(i, ref);
+                }
+                for (const auto& name : find_referenced_names(step.params, named_regex)) {
+                    if (auto it = name_to_index.find(name); it != name_to_index.end()) {
+                        add_dep(i, it->second);
                     }
                 }
-
-                // Also respect explicit 'depends_on' field if present
-                // (future enhancement - could add to WorkflowStep)
             }
 
             return deps;
@@ -186,6 +200,34 @@ namespace Orcha::Workflow {
             } else if (value.is_array()) {
                 for (const auto& elem : value.as_array()) {
                     find_refs_recursive(elem, pattern, refs);
+                }
+            }
+        }
+
+        // Named-reference variant: collects the captured step names.
+        [[nodiscard]] static std::unordered_set<std::string> find_referenced_names(
+            const web::json::value& params, const std::regex& pattern) {
+            std::unordered_set<std::string> names;
+            find_names_recursive(params, pattern, names);
+            return names;
+        }
+
+        static void find_names_recursive(
+            const web::json::value& value, const std::regex& pattern,
+            std::unordered_set<std::string>& names) {
+            if (value.is_string()) {
+                std::string str = value.as_string();
+                for (std::sregex_iterator it(str.begin(), str.end(), pattern), end;
+                     it != end; ++it) {
+                    names.insert((*it)[1].str());
+                }
+            } else if (value.is_object()) {
+                for (const auto& field : value.as_object()) {
+                    find_names_recursive(field.second, pattern, names);
+                }
+            } else if (value.is_array()) {
+                for (const auto& elem : value.as_array()) {
+                    find_names_recursive(elem, pattern, names);
                 }
             }
         }

--- a/src/orcha/workflow/WorkflowEngine.cpp
+++ b/src/orcha/workflow/WorkflowEngine.cpp
@@ -8,6 +8,7 @@
 #include <yaml-cpp/yaml.h>
 #include <regex>
 #include <algorithm>
+#include <ranges>
 
 namespace Orcha::Workflow {
 
@@ -120,7 +121,11 @@ namespace Orcha::Workflow {
             const std::string field_path = match[2].str();
             std::string replacement;
 
-            for (const auto& prev : previous_results) {
+            // Walk in reverse so the MOST RECENT step with this name wins when
+            // names are duplicated. This keeps resolution consistent with the
+            // parallel dependency analyzer, whose name_to_index map overwrites
+            // earlier entries and thus also resolves to the last such step.
+            for (const auto& prev : std::views::reverse(previous_results)) {
                 if (!prev.name.empty() && prev.name == step_name) {
                     replacement = json_value_to_string(
                         navigate_output(prev.output, field_path));

--- a/src/orcha/workflow/WorkflowEngine.cpp
+++ b/src/orcha/workflow/WorkflowEngine.cpp
@@ -90,6 +90,12 @@ namespace Orcha::Workflow {
         static const std::regex placeholder_regex(
             R"(\{\{step(\d+)\.output((?:\.[\w\d_]+)*)\}\})");
 
+        // Named references: {{steps.<name>.output.<path>}}. A step's optional
+        // name lets later steps reference it by name instead of brittle position.
+        // ("steps." prefix avoids any clash with the positional "stepN" form.)
+        static const std::regex named_regex(
+            R"(\{\{steps\.([A-Za-z_][\w]*)\.output((?:\.[\w\d_]+)*)\}\})");
+
         std::string result = input;
         std::smatch match;
 
@@ -104,6 +110,22 @@ namespace Orcha::Workflow {
                 auto value = navigate_output(
                     previous_results[step_index].output, field_path);
                 replacement = json_value_to_string(value);
+            }
+
+            result.replace(match.position(0), match.length(0), replacement);
+        }
+
+        while (std::regex_search(result, match, named_regex)) {
+            const std::string step_name = match[1].str();
+            const std::string field_path = match[2].str();
+            std::string replacement;
+
+            for (const auto& prev : previous_results) {
+                if (!prev.name.empty() && prev.name == step_name) {
+                    replacement = json_value_to_string(
+                        navigate_output(prev.output, field_path));
+                    break;
+                }
             }
 
             result.replace(match.position(0), match.length(0), replacement);
@@ -322,6 +344,7 @@ namespace Orcha::Workflow {
         result = executor_->execute_step(cmd, resolved_params);
         result.step_index = step_index;
         result.command_name = step.command_name;
+        result.name = step.name.value_or("");  // enables {{steps.<name>.output}} refs
 
         return result;
     }


### PR DESCRIPTION
This pull request introduces significant improvements to the job scheduling and dashboard experience in Orcha, along with some backend extensibility changes. The main updates include adding support for scheduled jobs using cron expressions, enhancing the job dashboard UI to show more job details and allow toggling job enablement, and improving step referencing in workflow definitions and visualizations.

**Job Scheduling and Dashboard Enhancements:**

* Added support for job scheduling with cron expressions and an enabled/disabled state. The dashboard UI now allows users to specify a schedule, enable or disable jobs, and view schedule status and badges. [[1]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R218-R221) [[2]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R369-R441) [[3]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L428-R508)
* The job run history section now highlights the selected run, auto-selects the latest run, and displays detailed output for each step, including errors, in a visually distinct card format. [[1]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L326-R360) [[2]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R369-R441) [[3]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R455-R468)

**Workflow Definition and Visualization Improvements:**

* Workflow steps can now be referenced by name (e.g., `{{steps.greet.output}}`) as well as by position (e.g., `{{step1.output}}`). The workflow diagram visualizer and default job definition have been updated to support and illustrate named steps. [[1]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L411-R495) [[2]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L446-R552) [[3]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L523-R612)

**Backend Extensibility and Integration:**

* The `CommandAgent` now accepts and passes a `PluginDenylist` to plugin admin routes, improving plugin management extensibility. [[1]](diffhunk://#diff-99d21cfb8864840ae5c285dc342aea91d524c921a82db4ddb4fe164a81a7c256L30-R31) [[2]](diffhunk://#diff-99d21cfb8864840ae5c285dc342aea91d524c921a82db4ddb4fe164a81a7c256L39-R41) [[3]](diffhunk://#diff-99d21cfb8864840ae5c285dc342aea91d524c921a82db4ddb4fe164a81a7c256L94-R96) [[4]](diffhunk://#diff-8b91ac9255829ea03f7f57c5cacaad5ba7533affc544ceef9b7f57a2af8036a8R12) [[5]](diffhunk://#diff-8b91ac9255829ea03f7f57c5cacaad5ba7533affc544ceef9b7f57a2af8036a8L56-R58) [[6]](diffhunk://#diff-8b91ac9255829ea03f7f57c5cacaad5ba7533affc544ceef9b7f57a2af8036a8R101)
* The CMake build configuration adds new source files for job scheduling and plugin denylist support, preparing for future backend features. [[1]](diffhunk://#diff-1f80f6fcdefc8c72d3447a5ccb35ba9311c06cefcfde1ba3e32df0ea4c4f71baR42) [[2]](diffhunk://#diff-1f80f6fcdefc8c72d3447a5ccb35ba9311c06cefcfde1ba3e32df0ea4c4f71baR77-R79)

**UI and Usability Improvements:**

* The dashboard's job list and job detail views now display schedule and enablement status, and provide controls to enable/disable jobs directly. [[1]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R218-R221) [[2]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R369-R441)
* Visual polish: new CSS for output cards, improved chart edge coloring, and more informative badges and tooltips. [[1]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32R133-R141) [[2]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L498-R596) [[3]](diffhunk://#diff-df20205f8b0c98002e701f3d3f9e5863298d7e79c283cb04377bf6f51fff3a32L523-R612)

These changes collectively make job automation more powerful and user-friendly, while laying groundwork for further backend extensibility.